### PR TITLE
Ensure both consoles get the same data

### DIFF
--- a/src/sketchup-developer-tools/ruby/devl_console.rb
+++ b/src/sketchup-developer-tools/ruby/devl_console.rb
@@ -219,13 +219,14 @@ class Console
   #
   # Args:
   # - data:  Object, the object to output via the console or puts!.
-  # - mthd:  Symbol, method to forward the data to. May be :puts! or :print!
+  # - output_method:  Symbol, method to forward the data to. May be :puts! or 
+  #    :print!
   #
-  def self.output(data, mthd=:puts!)
+  def self.output(data, output_method=:puts!)
     # If the developer console isn't active, fall-back to standard ruby output
     if @@rootConsole.nil? || !@@rootConsole.visible?
       # Note the ! here, which is how we alias the original puts function.
-      send(mthd, data)
+      send(output_method, data)
       return
     end
 
@@ -236,7 +237,7 @@ class Console
     str = str.gsub(/([^\\])'/, "\1\\'")
     # Abuse the fact that console.appendContent will plain write anything
     # that "looks like markup"
-    str = '<span class="output">' + str + '</span>' if mthd == :print!
+    str = '<span class="output">' + str + '</span>' if output_method == :print!
 
     @@rootConsole.execute_script(
       "try { console.appendContent('" + str + "')" + 
@@ -739,9 +740,10 @@ module Kernel
     #
     # Args:
     # - args: Object, the object (usually a string) to output.
-    # - mthd:  Symbol, method to forward the data to. May be :puts! or :print!
+    # - output_method:  Symbol, method to forward the data to. May be :puts! or
+    #    :print!
     # 
-    def puts_or_print(args, mthd)
+    def puts_or_print(args, output_method)
       # Regardless of whether we're in quiet mode or not we respect the
       # logging setting if set.
       if Developer::Console.logging?
@@ -762,7 +764,7 @@ module Kernel
         return
       else
         # Route to the console via our output method.
-        Developer::Console.output(args, mthd)
+        Developer::Console.output(args, output_method)
       end
     end
 


### PR DESCRIPTION
Testing the following code in the "developer console" works as expected, but not in the original console

``` ruby
puts "Testing newlines\n"
```

The original console would receive "Testing newlines&lt;br/&gt;".

This patch corrects the issue so that both consoles continue to work as expected.
