### PR TITLE
Method correction - New examples_errors branch

### DIFF
--- a/src/sketchup-developer-tools/testup/tests/ruby_classes/TC_Point3d.rb
+++ b/src/sketchup-developer-tools/testup/tests/ruby_classes/TC_Point3d.rb
@@ -499,7 +499,7 @@ class TC_Point3d < Test::Unit::TestCase
     assert_nothing_raised do
      point1 = Geom::Point3d.new 10,10,10
      vector = Geom::Vector3d.new(0,0,1)
-     point2 = point1.offset! vector
+     point2 = point1.offset vector
     end
   end
 #--------------------------------------------------------------------------


### PR DESCRIPTION
the "offset" method test was  using "offset!".

I'm also doing this using a new branch in my fork so as to keep corrections to little typos and example errors separate from any larger projects I might take on in their own branch.  Hopefully I'll get the hang of this multi-branch workflow.

Would it make sense to make a branch on your end Scott for little typos and corrections like this?  Or does that just introduce new levels of control that isn't needed at this point?
